### PR TITLE
Harden decoder and refresh CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,10 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request: null
+  workflow_dispatch: null
 
 jobs:
   run:
@@ -9,11 +12,11 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -23,7 +26,10 @@ jobs:
         tools: composer
 
     - name: Install Dependencies
-      run: composer install --prefer-dist
+      run: composer install --prefer-dist --no-interaction --no-progress
+
+    - name: Validate Composer Metadata
+      run: composer validate --strict --no-check-publish
 
     - name: Run PHPUnit
-      run: ./vendor/bin/phpunit
+      run: composer test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotnet-binary-xml
 
-[![Build Status](https://travis-ci.org/casperbiering/dotnet-binary-xml.png?branch=master)](https://travis-ci.org/casperbiering/dotnet-binary-xml)
+[![CI](https://github.com/casperbiering/dotnet-binary-xml/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/casperbiering/dotnet-binary-xml/actions/workflows/ci.yaml)
 
 **dotnet-binary-xml** is a PHP implementation of the [.NET Binary Format: XML Data Structure (MC-NBFX)](http://msdn.microsoft.com/en-us/library/cc219210.aspx).
 

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,28 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "CasperBiering\\Dotnet\\Tests\\": "src/"
+            "CasperBiering\\Dotnet\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "lint": [
+            "@php -l src/BinaryXml.php",
+            "@php -l src/BinaryXml/Encoder.php",
+            "@php -l src/BinaryXml/Decoder.php",
+            "@php -l src/BinaryXml/SoapEncoder.php",
+            "@php -l src/BinaryXml/SoapDecoder.php",
+            "@php -l src/BinaryXml/Constants.php",
+            "@php -l src/BinaryXml/SoapConstants.php",
+            "@php -l src/BinaryXml/DecodingException.php",
+            "@php -l src/BinaryXml/EncodingException.php",
+            "@php -l tests/BinaryXml/DecoderTest.php",
+            "@php -l tests/BinaryXml/EncoderTest.php",
+            "@php -l tests/BinaryXml/TwoWayTest.php",
+            "@php -l tests/BinaryXml/SoapDecoderTest.php",
+            "@php -l tests/BinaryXml/SoapEncoderTest.php",
+            "@php -l decode.php"
+        ]
     },
     "license": "MIT",
     "authors": [

--- a/src/BinaryXml/Decoder.php
+++ b/src/BinaryXml/Decoder.php
@@ -34,7 +34,8 @@ class Decoder
         }
 
         while ($pos < $contentLength) {
-            switch (ord($content[$pos])) {
+            $currentRecordType = $this->peekByte($content, $pos);
+            switch ($currentRecordType) {
                 case Constants::RECORD_TYPE_END_ELEMENT:
                     $pos += 1;
 
@@ -51,17 +52,15 @@ class Decoder
                     $pos += 1;
 
                     // Element
-                    $pos += 1; // expect it to be 0x40
+                    $this->readByte($content, $pos); // expect it to be 0x40
                     $element = $this->readString($content, $pos);
-                    $pos += 1; // expect it to be 0x01
+                    $this->readByte($content, $pos); // expect it to be 0x01
 
                     // Record type
-                    $recordType = ord($content[$pos]);
-                    $pos += 1;
+                    $recordType = $this->readByte($content, $pos);
 
                     // Length
-                    $length = ord($content[$pos]);
-                    $pos += 1;
+                    $length = $this->readByte($content, $pos);
 
                     // Entries
                     for ($entry = 0; $entry < $length; $entry++) {
@@ -168,8 +167,7 @@ class Decoder
                 case Constants::RECORD_TYPE_PREFIX_DICTIONARY_ATTRIBUTE_X:
                 case Constants::RECORD_TYPE_PREFIX_DICTIONARY_ATTRIBUTE_Y:
                 case Constants::RECORD_TYPE_PREFIX_DICTIONARY_ATTRIBUTE_Z:
-                    $char = chr(85 + ord($content[$pos]));
-                    $pos += 1;
+                    $char = chr(85 + $this->readByte($content, $pos));
 
                     $name = $this->readDictionaryString($content, $pos);
                     $value = $this->readTextRecord($content, $pos);
@@ -202,8 +200,7 @@ class Decoder
                 case Constants::RECORD_TYPE_PREFIX_ATTRIBUTE_X:
                 case Constants::RECORD_TYPE_PREFIX_ATTRIBUTE_Y:
                 case Constants::RECORD_TYPE_PREFIX_ATTRIBUTE_Z:
-                    $char = chr(59 + ord($content[$pos]));
-                    $pos += 1;
+                    $char = chr(59 + $this->readByte($content, $pos));
 
                     $name = $this->readString($content, $pos);
                     $value = $this->readTextRecord($content, $pos);
@@ -262,8 +259,7 @@ class Decoder
                 case Constants::RECORD_TYPE_PREFIX_DICTIONARY_ELEMENT_X:
                 case Constants::RECORD_TYPE_PREFIX_DICTIONARY_ELEMENT_Y:
                 case Constants::RECORD_TYPE_PREFIX_DICTIONARY_ELEMENT_Z:
-                    $char = chr(29 + ord($content[$pos]));
-                    $pos += 1;
+                    $char = chr(29 + $this->readByte($content, $pos));
 
                     $name = $this->readDictionaryString($content, $pos);
 
@@ -295,8 +291,7 @@ class Decoder
                 case Constants::RECORD_TYPE_PREFIX_ELEMENT_X:
                 case Constants::RECORD_TYPE_PREFIX_ELEMENT_Y:
                 case Constants::RECORD_TYPE_PREFIX_ELEMENT_Z:
-                    $char = chr(3 + ord($content[$pos]));
-                    $pos += 1;
+                    $char = chr(3 + $this->readByte($content, $pos));
 
                     $name = $this->readString($content, $pos);
 
@@ -370,7 +365,7 @@ class Decoder
                     $writer->fullEndElement();
                 break;
                 default:
-                    throw new DecodingException(sprintf('Unknown record type 0x%02X at position %d.', ord($content[$pos]), $pos));
+                    throw new DecodingException(sprintf('Unknown record type 0x%02X at position %d.', $currentRecordType, $pos));
                 break;
             }
         }
@@ -384,17 +379,15 @@ class Decoder
         $value = 0;
         $last = 0x80;
         for ($i = 0; $i < 4 && ($last & 0x80); $i++) {
-            $last = ord($content[$pos]);
+            $last = $this->readByte($content, $pos);
             $value += ($last & 0x7F) << ($i * 7);
-            $pos++;
         }
         if ($i == 4 && $last & 0x80) {
-            $last = ord($content[$pos]);
+            $last = $this->readByte($content, $pos);
             if (($last & 0x7) !== $last) {
                 throw new DecodingException(sprintf('Invalid MultiByteInt31 at position %d.', $start));
             }
             $value += ($last & 0x7) << 28;
-            $pos++;
         }
 
         return $value;
@@ -411,16 +404,14 @@ class Decoder
     {
         $recordLength = $this->readMultiByteInt31($content, $pos);
 
-        $record = substr($content, $pos, $recordLength);
-        $pos += $recordLength;
+        $record = $this->readBytes($content, $pos, $recordLength);
 
         return $record;
     }
 
     protected function readTextRecord(&$content, &$pos)
     {
-        $recordType = ord($content[$pos]);
-        $pos += 1;
+        $recordType = $this->readByte($content, $pos);
 
         return $this->readTextRecordInner($content, $pos, $recordType);
     }
@@ -446,24 +437,15 @@ class Decoder
             break;
             case Constants::RECORD_TYPE_INT8_TEXT:
             case Constants::RECORD_TYPE_INT8_TEXT_WITH_END_ELEMENT:
-                $record = unpack('c*', $content[$pos]);
-                $pos += 1;
-
-                return (string) $record[1];
+                return (string) $this->readInt8($content, $pos);
             break;
             case Constants::RECORD_TYPE_INT16_TEXT:
             case Constants::RECORD_TYPE_INT16_TEXT_WITH_END_ELEMENT:
-                $record = unpack('s*', substr($content, $pos, 2));
-                $pos += 2;
-
-                return (string) $record[1];
+                return (string) $this->readInt16LE($content, $pos);
             break;
             case Constants::RECORD_TYPE_INT32_TEXT:
             case Constants::RECORD_TYPE_INT32_TEXT_WITH_END_ELEMENT:
-                $record = unpack('l*', substr($content, $pos, 4));
-                $pos += 4;
-
-                return (string) $record[1];
+                return (string) $this->readInt32LE($content, $pos);
             break;
             case Constants::RECORD_TYPE_INT64_TEXT:
             case Constants::RECORD_TYPE_INT64_TEXT_WITH_END_ELEMENT:
@@ -472,22 +454,22 @@ class Decoder
                     throw new DecodingException('Int64 requires GMP extension');
                 }
 
-                list(, $int64Hex) = unpack('H*', strrev(substr($content, $pos, 8)));
-                $pos += 8;
+                $value = $this->readUInt64LE($content, $pos);
+                if (gmp_cmp($value, gmp_pow(2, 63)) >= 0) {
+                    $value = gmp_sub($value, gmp_pow(2, 64));
+                }
 
-                return (string) gmp_strval(gmp_init($int64Hex, 16), 10);
+                return (string) gmp_strval($value, 10);
             break;
             case Constants::RECORD_TYPE_FLOAT_TEXT:
             case Constants::RECORD_TYPE_FLOAT_TEXT_WITH_END_ELEMENT:
-                $record = unpack('f*', substr($content, $pos, 4));
-                $pos += 4;
+                $record = unpack('g', $this->readBytes($content, $pos, 4));
 
                 return (string) $record[1];
             break;
             case Constants::RECORD_TYPE_DOUBLE_TEXT:
             case Constants::RECORD_TYPE_DOUBLE_TEXT_WITH_END_ELEMENT:
-                $record = unpack('d*', substr($content, $pos, 8));
-                $pos += 8;
+                $record = unpack('e', $this->readBytes($content, $pos, 8));
 
                 return (string) $record[1];
             break;
@@ -498,20 +480,16 @@ class Decoder
                     throw new DecodingException('Decimal requires GMP extension');
                 }
 
-                $pos += 2; // First 2 bytes reserved
+                $this->readBytes($content, $pos, 2); // First 2 bytes reserved
 
-                $scale = ord($content[$pos]);
-                $pos += 1;
+                $scale = $this->readByte($content, $pos);
 
-                $sign = ord($content[$pos]);
-                $pos += 1;
+                $sign = $this->readByte($content, $pos);
 
-                list(, $hi32Hex) = unpack('H*', strrev(substr($content, $pos, 4)));
-                $pos += 4;
+                list(, $hi32Hex) = unpack('H*', strrev($this->readBytes($content, $pos, 4)));
                 $hi32 = gmp_init($hi32Hex, 16);
 
-                list(, $lo64Hex) = unpack('H*', strrev(substr($content, $pos, 8)));
-                $pos += 8;
+                list(, $lo64Hex) = unpack('H*', strrev($this->readBytes($content, $pos, 8)));
                 $lo64 = gmp_init($lo64Hex, 16);
 
                 $value = gmp_add(gmp_mul($hi32, gmp_pow(2, 64)), $lo64);
@@ -526,7 +504,7 @@ class Decoder
                     $record = substr($record, 0, strlen($record) - $scale).'.'.substr($record, $scale * -1);
 
                     $record = trim($record, '0');
-                    if ($record[0] == '.') {
+                    if ($record === '' || $record[0] == '.') {
                         $record = '0'.$record;
                     }
                 }
@@ -547,10 +525,9 @@ class Decoder
 
                 $binary = '';
                 for ($i = 0; $i < 8; $i++) {
-                    list(, $byteint) = unpack('C*', $content[$pos + $i]);
+                    list(, $byteint) = unpack('C*', $this->readBytes($content, $pos, 1));
                     $binary = sprintf('%08b', $byteint).$binary;
                 }
-                $pos += 8;
 
                 $value = gmp_init(substr($binary, 2, 62), 2);
 
@@ -570,11 +547,11 @@ class Decoder
 
                 // Join different time elements
                 if ($fraction !== '0000000') {
-                    $record = "${date}T${time}.${fraction}";
+                    $record = "{$date}T{$time}.{$fraction}";
                 } elseif ($time !== '00:00:00') {
-                    $record = "${date}T${time}";
+                    $record = "{$date}T{$time}";
                 } else {
-                    $record = "${date}";
+                    $record = "{$date}";
                 }
 
                 // Add timezone info
@@ -589,68 +566,56 @@ class Decoder
             break;
             case Constants::RECORD_TYPE_CHARS8_TEXT:
             case Constants::RECORD_TYPE_CHARS8_TEXT_WITH_END_ELEMENT:
-                list(, $recordLength) = unpack('C*', $content[$pos]);
-                $pos += 1;
+                $recordLength = $this->readByte($content, $pos);
 
-                $record = substr($content, $pos, $recordLength);
-                $pos += $recordLength;
+                $record = $this->readBytes($content, $pos, $recordLength);
 
                 return $record;
             break;
             case Constants::RECORD_TYPE_CHARS16_TEXT:
             case Constants::RECORD_TYPE_CHARS16_TEXT_WITH_END_ELEMENT:
-                list(, $recordLength) = unpack('S*', substr($content, $pos, 2));
-                $pos += 2;
+                $recordLength = $this->readUInt16LE($content, $pos);
 
-                $record = substr($content, $pos, $recordLength);
-                $pos += $recordLength;
+                $record = $this->readBytes($content, $pos, $recordLength);
 
                 return $record;
             break;
             case Constants::RECORD_TYPE_CHARS32_TEXT:
             case Constants::RECORD_TYPE_CHARS32_TEXT_WITH_END_ELEMENT:
-                list(, $recordLength) = unpack('l*', substr($content, $pos, 4));
-                $pos += 4;
+                $recordLength = $this->readUInt32LE($content, $pos);
 
-                $record = substr($content, $pos, $recordLength);
-                $pos += $recordLength;
+                $record = $this->readBytes($content, $pos, $recordLength);
 
                 return $record;
             break;
             case Constants::RECORD_TYPE_BYTES8_TEXT:
             case Constants::RECORD_TYPE_BYTES8_TEXT_WITH_END_ELEMENT:
-                list(, $recordLength) = unpack('C*', $content[$pos]);
-                $pos += 1;
+                $recordLength = $this->readByte($content, $pos);
 
-                $record = substr($content, $pos, $recordLength);
-                $pos += $recordLength;
+                $record = $this->readBytes($content, $pos, $recordLength);
 
                 return base64_encode($record);
             break;
             case Constants::RECORD_TYPE_BYTES16_TEXT:
             case Constants::RECORD_TYPE_BYTES16_TEXT_WITH_END_ELEMENT:
-                list(, $recordLength) = unpack('S*', substr($content, $pos, 2));
-                $pos += 2;
+                $recordLength = $this->readUInt16LE($content, $pos);
 
-                $record = substr($content, $pos, $recordLength);
-                $pos += $recordLength;
+                $record = $this->readBytes($content, $pos, $recordLength);
 
                 return base64_encode($record);
             break;
             case Constants::RECORD_TYPE_BYTES32_TEXT:
             case Constants::RECORD_TYPE_BYTES32_TEXT_WITH_END_ELEMENT:
-                list(, $recordLength) = unpack('l*', substr($content, $pos, 4));
-                $pos += 4;
+                $recordLength = $this->readUInt32LE($content, $pos);
 
-                $record = substr($content, $pos, $recordLength);
-                $pos += $recordLength;
+                $record = $this->readBytes($content, $pos, $recordLength);
 
                 return base64_encode($record);
             break;
             case Constants::RECORD_TYPE_START_LIST_TEXT:
 
                 $record = '';
-                while (ord($content[$pos]) != Constants::RECORD_TYPE_END_LIST_TEXT) {
+                while ($this->peekByte($content, $pos) != Constants::RECORD_TYPE_END_LIST_TEXT) {
                     if ($record !== '') {
                         $record .= ' ';
                     }
@@ -674,20 +639,15 @@ class Decoder
             case Constants::RECORD_TYPE_UUID_TEXT:
             case Constants::RECORD_TYPE_UUID_TEXT_WITH_END_ELEMENT:
 
-                list(, $data1) = unpack('H*', strrev(substr($content, $pos, 4)));
-                $pos += 4;
+                list(, $data1) = unpack('H*', strrev($this->readBytes($content, $pos, 4)));
 
-                list(, $data2) = unpack('H*', strrev(substr($content, $pos, 2)));
-                $pos += 2;
+                list(, $data2) = unpack('H*', strrev($this->readBytes($content, $pos, 2)));
 
-                list(, $data3) = unpack('H*', strrev(substr($content, $pos, 2)));
-                $pos += 2;
+                list(, $data3) = unpack('H*', strrev($this->readBytes($content, $pos, 2)));
 
-                list(, $data4) = unpack('H*', substr($content, $pos, 2));
-                $pos += 2;
+                list(, $data4) = unpack('H*', $this->readBytes($content, $pos, 2));
 
-                list(, $data5) = unpack('H*', substr($content, $pos, 6));
-                $pos += 6;
+                list(, $data5) = unpack('H*', $this->readBytes($content, $pos, 6));
 
                 $record = "{$data1}-{$data2}-{$data3}-{$data4}-{$data5}";
 
@@ -706,10 +666,9 @@ class Decoder
 
                 $value = '';
                 for ($i = 0; $i < 8; $i++) {
-                    list(, $byte) = unpack('C*', $content[$pos + $i]);
+                    list(, $byte) = unpack('C*', $this->readBytes($content, $pos, 1));
                     $value = sprintf('%08b', $byte).$value;
                 }
-                $pos += 8;
 
                 $value = gmp_init($value, 2);
 
@@ -749,7 +708,7 @@ class Decoder
                     if ($secs > 0 || $fracs > 0) {
                         $record .= $secs;
                         if ($fracs > 0) {
-                            $record .= '.'.$fracs;
+                            $record .= '.'.str_pad((string) $fracs, 7, '0', STR_PAD_LEFT);
                         }
                         $record .= 'S';
                     }
@@ -764,15 +723,11 @@ class Decoder
                     throw new DecodingException('Uint64 requires GMP extension');
                 }
 
-                list(, $uint64Hex) = unpack('H*', strrev(substr($content, $pos, 8)));
-                $pos += 8;
-
-                return (string) gmp_strval(gmp_init($uint64Hex, 16), 10);
+                return (string) gmp_strval($this->readUInt64LE($content, $pos), 10);
             break;
             case Constants::RECORD_TYPE_BOOL_TEXT:
             case Constants::RECORD_TYPE_BOOL_TEXT_WITH_END_ELEMENT:
-                $record = ord($content[$pos]);
-                $pos += 1;
+                $record = $this->readByte($content, $pos);
                 switch ($record) {
                     case 0:
                         return 'false';
@@ -786,38 +741,31 @@ class Decoder
             break;
             case Constants::RECORD_TYPE_UNICODECHARS8_TEXT:
             case Constants::RECORD_TYPE_UNICODECHARS8_TEXT_WITH_END_ELEMENT:
-                list(, $recordLength) = unpack('C*', $content[$pos]);
-                $pos += 1;
+                $recordLength = $this->readByte($content, $pos);
 
-                $record = substr($content, $pos, $recordLength);
-                $pos += $recordLength;
+                $record = $this->readBytes($content, $pos, $recordLength);
 
                 return mb_convert_encoding($record, 'UTF-8', 'UTF-16');
             break;
             case Constants::RECORD_TYPE_UNICODECHARS16_TEXT:
             case Constants::RECORD_TYPE_UNICODECHARS16_TEXT_WITH_END_ELEMENT:
-                list(, $recordLength) = unpack('S*', substr($content, $pos, 2));
-                $pos += 2;
+                $recordLength = $this->readUInt16LE($content, $pos);
 
-                $record = substr($content, $pos, $recordLength);
-                $pos += $recordLength;
+                $record = $this->readBytes($content, $pos, $recordLength);
 
                 return mb_convert_encoding($record, 'UTF-8', 'UTF-16');
             break;
             case Constants::RECORD_TYPE_UNICODECHARS32_TEXT:
             case Constants::RECORD_TYPE_UNICODECHARS32_TEXT_WITH_END_ELEMENT:
-                list(, $recordLength) = unpack('l*', substr($content, $pos, 4));
-                $pos += 4;
+                $recordLength = $this->readUInt32LE($content, $pos);
 
-                $record = substr($content, $pos, $recordLength);
-                $pos += $recordLength;
+                $record = $this->readBytes($content, $pos, $recordLength);
 
                 return mb_convert_encoding($record, 'UTF-8', 'UTF-16');
             break;
             case Constants::RECORD_TYPE_QNAMEDICTIONARY_TEXT:
             case Constants::RECORD_TYPE_QNAMEDICTIONARY_TEXT_WITH_END_ELEMENT:
-                $prefix = chr(97 + ord($content[$pos]));
-                $pos += 1;
+                $prefix = chr(97 + $this->readByte($content, $pos));
 
                 $name = $this->readDictionaryString($content, $pos);
 
@@ -826,6 +774,80 @@ class Decoder
             default:
                 throw new DecodingException(sprintf('Unknown record type 0x%02X at position %d.', $recordType, $pos));
             break;
+        }
+    }
+
+    protected function peekByte(&$content, $pos)
+    {
+        $this->assertAvailable($content, $pos, 1);
+
+        return ord($content[$pos]);
+    }
+
+    protected function readByte(&$content, &$pos)
+    {
+        $byte = $this->peekByte($content, $pos);
+        $pos += 1;
+
+        return $byte;
+    }
+
+    protected function readBytes(&$content, &$pos, $length)
+    {
+        $this->assertAvailable($content, $pos, $length);
+
+        $bytes = substr($content, $pos, $length);
+        $pos += $length;
+
+        return $bytes;
+    }
+
+    protected function readInt8(&$content, &$pos)
+    {
+        $value = $this->readByte($content, $pos);
+
+        return $value >= 0x80 ? $value - 0x100 : $value;
+    }
+
+    protected function readUInt16LE(&$content, &$pos)
+    {
+        $record = unpack('v', $this->readBytes($content, $pos, 2));
+
+        return $record[1];
+    }
+
+    protected function readInt16LE(&$content, &$pos)
+    {
+        $value = $this->readUInt16LE($content, $pos);
+
+        return $value >= 0x8000 ? $value - 0x10000 : $value;
+    }
+
+    protected function readUInt32LE(&$content, &$pos)
+    {
+        $record = unpack('V', $this->readBytes($content, $pos, 4));
+
+        return $record[1];
+    }
+
+    protected function readInt32LE(&$content, &$pos)
+    {
+        $value = $this->readUInt32LE($content, $pos);
+
+        return $value >= 0x80000000 ? $value - 0x100000000 : $value;
+    }
+
+    protected function readUInt64LE(&$content, &$pos)
+    {
+        list(, $hex) = unpack('H*', strrev($this->readBytes($content, $pos, 8)));
+
+        return gmp_init($hex, 16);
+    }
+
+    protected function assertAvailable(&$content, $pos, $length)
+    {
+        if ($length < 0 || $pos < 0 || strlen($content) - $pos < $length) {
+            throw new DecodingException(sprintf('Unexpected end of content at position %d.', $pos));
         }
     }
 

--- a/src/BinaryXml/Encoder.php
+++ b/src/BinaryXml/Encoder.php
@@ -38,79 +38,94 @@ class Encoder
             return '';
         }
 
+        $previousUseInternalErrors = libxml_use_internal_errors(true);
         libxml_clear_errors();
         $reader = new XMLReader();
-        $reader->xml($xml);
+        if (!$reader->xml($xml)) {
+            $last_error = libxml_get_last_error();
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousUseInternalErrors);
 
-        $binary = '';
-        while (@$reader->read()) {
-            switch ($reader->nodeType) {
-                case XMLReader::NONE:
-                    break;
+            $message = $last_error === false ? 'Unknown XML parsing error' : rtrim($last_error->message);
 
-                case XMLReader::ELEMENT:
-                    $index = $this->getDictionaryIndex($reader->localName);
-                    if ($reader->prefix && $index !== false) {
-                        $binary .= chr(Constants::RECORD_TYPE_DICTIONARY_ELEMENT);
-                        $this->writeString($binary, $reader->prefix);
-                        $this->writeDictionaryString($binary, $index);
-                    } elseif ($reader->prefix) {
-                        $binary .= chr(Constants::RECORD_TYPE_ELEMENT);
-                        $this->writeString($binary, $reader->prefix);
-                        $this->writeString($binary, $reader->localName);
-                    } elseif ($index !== false) {
-                        $binary .= chr(Constants::RECORD_TYPE_SHORT_DICTIONARY_ELEMENT);
-                        $this->writeDictionaryString($binary, $index);
-                    } else {
-                        $binary .= chr(Constants::RECORD_TYPE_SHORT_ELEMENT);
-                        $this->writeString($binary, $reader->localName);
-                    }
-                    $emptyElement = $reader->isEmptyElement;
-                    $this->writeAttributes($binary, $reader);
-                    if ($emptyElement) {
-                        $binary .= chr(Constants::RECORD_TYPE_END_ELEMENT);
-                    }
-                    break;
-
-                case XMLReader::TEXT:
-                    $this->writeTextRecord($binary, $reader->value);
-                    break;
-
-                case XMLReader::COMMENT:
-                    $binary .= chr(Constants::RECORD_TYPE_COMMENT);
-                    $this->writeString($binary, $reader->value);
-                    break;
-
-                case XMLReader::WHITESPACE:
-                    break;
-
-                case XMLReader::SIGNIFICANT_WHITESPACE:
-                    $this->writeTextRecord($binary, $reader->value);
-                    break;
-
-                case XMLReader::END_ELEMENT:
-                    // TODO: Use *_WITH_END_ELEMENT if possible
-                    $binary .= chr(Constants::RECORD_TYPE_END_ELEMENT);
-                    break;
-
-                case XMLReader::ATTRIBUTE:
-                    throw new EncodingException('Invalid encoding state.');
-                case XMLReader::DOC:
-                case XMLReader::DOC_TYPE:
-                case XMLReader::DOC_FRAGMENT:
-                case XMLReader::NOTATION:
-                case XMLReader::XML_DECLARATION:
-                case XMLReader::CDATA:
-                case XMLReader::ENTITY:
-                case XMLReader::ENTITY_REF:
-                case XMLReader::END_ENTITY:
-                case XMLReader::PI:
-                default:
-                    throw new EncodingException(sprintf('Unsupported XML node type %d.', $reader->nodeType));
-            }
+            throw new EncodingException(sprintf('XML Parsing Error "%s".', $message));
         }
 
-        $last_error = libxml_get_last_error();
+        $binary = '';
+        try {
+            while ($reader->read()) {
+                switch ($reader->nodeType) {
+                    case XMLReader::NONE:
+                        break;
+
+                    case XMLReader::ELEMENT:
+                        $index = $this->getDictionaryIndex($reader->localName);
+                        if ($reader->prefix && $index !== false) {
+                            $binary .= chr(Constants::RECORD_TYPE_DICTIONARY_ELEMENT);
+                            $this->writeString($binary, $reader->prefix);
+                            $this->writeDictionaryString($binary, $index);
+                        } elseif ($reader->prefix) {
+                            $binary .= chr(Constants::RECORD_TYPE_ELEMENT);
+                            $this->writeString($binary, $reader->prefix);
+                            $this->writeString($binary, $reader->localName);
+                        } elseif ($index !== false) {
+                            $binary .= chr(Constants::RECORD_TYPE_SHORT_DICTIONARY_ELEMENT);
+                            $this->writeDictionaryString($binary, $index);
+                        } else {
+                            $binary .= chr(Constants::RECORD_TYPE_SHORT_ELEMENT);
+                            $this->writeString($binary, $reader->localName);
+                        }
+                        $emptyElement = $reader->isEmptyElement;
+                        $this->writeAttributes($binary, $reader);
+                        if ($emptyElement) {
+                            $binary .= chr(Constants::RECORD_TYPE_END_ELEMENT);
+                        }
+                        break;
+
+                    case XMLReader::TEXT:
+                        $this->writeTextRecord($binary, $reader->value);
+                        break;
+
+                    case XMLReader::COMMENT:
+                        $binary .= chr(Constants::RECORD_TYPE_COMMENT);
+                        $this->writeString($binary, $reader->value);
+                        break;
+
+                    case XMLReader::WHITESPACE:
+                        break;
+
+                    case XMLReader::SIGNIFICANT_WHITESPACE:
+                        $this->writeTextRecord($binary, $reader->value);
+                        break;
+
+                    case XMLReader::END_ELEMENT:
+                        // TODO: Use *_WITH_END_ELEMENT if possible
+                        $binary .= chr(Constants::RECORD_TYPE_END_ELEMENT);
+                        break;
+
+                    case XMLReader::ATTRIBUTE:
+                        throw new EncodingException('Invalid encoding state.');
+                    case XMLReader::DOC:
+                    case XMLReader::DOC_TYPE:
+                    case XMLReader::DOC_FRAGMENT:
+                    case XMLReader::NOTATION:
+                    case XMLReader::XML_DECLARATION:
+                    case XMLReader::CDATA:
+                    case XMLReader::ENTITY:
+                    case XMLReader::ENTITY_REF:
+                    case XMLReader::END_ENTITY:
+                    case XMLReader::PI:
+                    default:
+                        throw new EncodingException(sprintf('Unsupported XML node type %d.', $reader->nodeType));
+                }
+            }
+
+            $last_error = libxml_get_last_error();
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousUseInternalErrors);
+        }
+
         if ($last_error !== false) {
             throw new EncodingException(sprintf('XML Parsing Error "%s".', rtrim($last_error->message)));
         }

--- a/tests/BinaryXml/DecoderTest.php
+++ b/tests/BinaryXml/DecoderTest.php
@@ -61,6 +61,17 @@ class DecoderTest extends \PHPUnit\Framework\TestCase
         $decoder->decode($binary);
     }
 
+    public function testTruncatedString()
+    {
+        $this->expectException(\CasperBiering\Dotnet\BinaryXml\DecodingException::class);
+        $this->expectExceptionMessage('Unexpected end of content at position 2.');
+
+        $binary = $this->convertToBinary('40 03 64 6F');
+        $decoder = new Decoder();
+
+        $decoder->decode($binary);
+    }
+
     public function testInvalidRecordType()
     {
         $this->expectException(\CasperBiering\Dotnet\BinaryXml\DecodingException::class);
@@ -184,12 +195,14 @@ class DecoderTest extends \PHPUnit\Framework\TestCase
             ['42 80 80 80 01 01', '<str2097152></str2097152>'],
             ['42 80 80 80 80 01 01', '<str268435456></str268435456>'],
             ['40 03 64 6F 63 06 EC 01 8E 00 00 00 80 00 00 00 00 01', '<doc str236="2147483648"></doc>'],
+            ['40 03 64 6F 63 8F FF FF FF FF FF FF FF FF', '<doc>-1</doc>'],
             ['42 9A 01 8F 00 00 00 00 00 01 00 00', '<str154>1099511627776</str154>'],
             ['40 03 64 6F 63 B2 FF FF FF FF FF FF FF FF 01', '<doc>18446744073709551615</doc>'],
             ['42 9A 01 B3 FE FF FF FF FF FF FF FF', '<str154>18446744073709551614</str154>'],
             ['40 03 64 6F 63 AC 00 11 22 33 44 55 66 77 88 99 AA BB CC DD EE FF 01', '<doc>urn:uuid:33221100-5544-7766-8899-aabbccddeeff</doc>'],
             ['42 1A AD 00 11 22 33 44 55 66 77 88 99 AA BB CC DD EE FF', '<str26>urn:uuid:33221100-5544-7766-8899-aabbccddeeff</str26>'],
             ['40 03 64 6F 63 AE 00 C4 F5 32 FF FF FF FF 01', '<doc>-PT5M44S</doc>'],
+            ['40 03 64 6F 63 AE 01 00 00 00 00 00 00 00 01', '<doc>PT0.0000001S</doc>'],
             ['42 94 07 AF 00 B0 8E F0 1B 00 00 00', '<str916>PT3H20M</str916>'],
             ['40 03 64 6F 63 B0 00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 01', '<doc>03020100-0504-0706-0809-0a0b0c0d0e0f</doc>'],
             ['40 02 49 44 B1 00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F', '<ID>03020100-0504-0706-0809-0a0b0c0d0e0f</ID>'],


### PR DESCRIPTION
## Summary
- harden binary decoder reads and use explicit little-endian helpers
- fix signed Int64 decoding and TimeSpan fractional formatting
- remove XMLReader error suppression and restore libxml state
- refresh Composer scripts/autoload, CI matrix, README badge, and add .editorconfig

## Tests
- composer validate --strict --no-check-publish
- composer lint
- composer test